### PR TITLE
Remove padding from hero images and fix table width

### DIFF
--- a/src/app/contact-page/contact-page.tsx
+++ b/src/app/contact-page/contact-page.tsx
@@ -24,8 +24,8 @@ const _ContactPage = ({ className }: { className?: string }) => {
       <Page.Title description="서강대학교 학부생이라면 누구나 함께할 수 있습니다.">
         가입 및 문의
       </Page.Title>
+      <HeroImage src={LabK512Image} alt="K512 Lab" />
       <Page.Body>
-        <HeroImage src={LabK512Image} alt="K512 Lab" />
         <Section>
           <Section.Title>가입</Section.Title>
           <Section.Body>

--- a/src/app/history-page/history-page.tsx
+++ b/src/app/history-page/history-page.tsx
@@ -42,8 +42,8 @@ const _HistoryPage = ({ className }: { className?: string }) => {
       <Page.Title description="매년 여러 대회에 참가해 우수한 성적을 거두고 있습니다.">
         기록
       </Page.Title>
+      <HeroImage src={ScoreboardImage} alt="scoreboard" />
       <Page.Body>
-        <HeroImage src={ScoreboardImage} alt="scoreboard" />
         <SelectedHistoryContextProvider initialValue={{ year: 2024 }}>
           <Section>
             <Section.Title>

--- a/src/app/introduction-page/introduction-page.tsx
+++ b/src/app/introduction-page/introduction-page.tsx
@@ -40,8 +40,8 @@ const _IntroductionPage = ({ className }: { className?: string }) => {
       <Page.Title description="우리는 알고리즘을 공부하고, 알고리즘으로 문제를 해결합니다.">
         소개
       </Page.Title>
+      <HeroImage src={ICPC2019RedshiftImage} alt="ICPC 2019 Redshift" />
       <Page.Body>
-        <HeroImage src={ICPC2019RedshiftImage} alt="ICPC 2019 Redshift" />
         <Section>
           <Section.Title>이곳은</Section.Title>
           <Section.Body>
@@ -115,7 +115,9 @@ const _IntroductionPage = ({ className }: { className?: string }) => {
             </ButtonWrapper>
           </Section.Body>
         </Section>
-        <HeroImage src={AcmSolvingImage} alt="acm solving" />
+      </Page.Body>
+      <HeroImage src={AcmSolvingImage} alt="acm solving" />
+      <Page.Body>
         <Section>
           <Section.Title>알고리즘 스터디</Section.Title>
           <Section.Body>

--- a/src/app/main-page/main-page.tsx
+++ b/src/app/main-page/main-page.tsx
@@ -44,62 +44,66 @@ const ArrowRight = styled(ArrowRightIcon)`
 `;
 const _MainPage = ({ className }: { className?: string }) => {
   return (
-    <Page className={className}>
-      <Page.Body>
-        <Section>
-          <HeroTitle>
-            Make it.
-            <br />
-            Solve it.
-          </HeroTitle>
-          <HeroDescription>
-            Sogang ICPC Team —<br />
-            서강대학교 컴퓨터공학과 알고리즘 문제해결 학회
-            <br />
-          </HeroDescription>
-        </Section>
+    <>
+      <Page className={className}>
+        <Page.Body>
+          <Section>
+            <HeroTitle>
+              Make it.
+              <br />
+              Solve it.
+            </HeroTitle>
+            <HeroDescription>
+              Sogang ICPC Team —<br />
+              서강대학교 컴퓨터공학과 알고리즘 문제해결 학회
+              <br />
+            </HeroDescription>
+          </Section>
+        </Page.Body>
         <HeroImage src={ICPCWF21Image} alt="21 ICPC World Finals" />
-        <Section>
-          <Section.Title>소개</Section.Title>
-          <SitemapSectionBody>
-            우리는 알고리즘을 공부하고, 알고리즘으로 문제를 해결합니다.{" "}
-            <IconLink to="/introduction">
-              <ArrowRight />
-            </IconLink>
-          </SitemapSectionBody>
-        </Section>
-        <Hr />
-        <Section>
-          <Section.Title>기록</Section.Title>
-          <SitemapSectionBody>
-            매년 여러 대회에 참가해 우수한 성적을 거두고 있습니다.{" "}
-            <IconLink to="/history">
-              <ArrowRight />
-            </IconLink>
-          </SitemapSectionBody>
-        </Section>
-        <Hr />
-        <Section>
-          <Section.Title>Sogang Programming Contest</Section.Title>
-          <SitemapSectionBody>
-            논리력과 문제 해결 능력을 겨루는 대회입니다.{" "}
-            <IconLink to="/spc">
-              <ArrowRight />
-            </IconLink>
-          </SitemapSectionBody>
-        </Section>
-        <Hr />
-        <Section>
-          <Section.Title>가입 및 문의</Section.Title>
-          <SitemapSectionBody>
-            서강대학교 학부생이라면 누구나 함께할 수 있습니다.{" "}
-            <IconLink to="/contact">
-              <ArrowRight />
-            </IconLink>
-          </SitemapSectionBody>
-        </Section>
-      </Page.Body>
-    </Page>
+        <Page.Body>
+          <Section>
+            <Section.Title>소개</Section.Title>
+            <SitemapSectionBody>
+              우리는 알고리즘을 공부하고, 알고리즘으로 문제를 해결합니다.{" "}
+              <IconLink to="/introduction">
+                <ArrowRight />
+              </IconLink>
+            </SitemapSectionBody>
+          </Section>
+          <Hr />
+          <Section>
+            <Section.Title>기록</Section.Title>
+            <SitemapSectionBody>
+              매년 여러 대회에 참가해 우수한 성적을 거두고 있습니다.{" "}
+              <IconLink to="/history">
+                <ArrowRight />
+              </IconLink>
+            </SitemapSectionBody>
+          </Section>
+          <Hr />
+          <Section>
+            <Section.Title>Sogang Programming Contest</Section.Title>
+            <SitemapSectionBody>
+              논리력과 문제 해결 능력을 겨루는 대회입니다.{" "}
+              <IconLink to="/spc">
+                <ArrowRight />
+              </IconLink>
+            </SitemapSectionBody>
+          </Section>
+          <Hr />
+          <Section>
+            <Section.Title>가입 및 문의</Section.Title>
+            <SitemapSectionBody>
+              서강대학교 학부생이라면 누구나 함께할 수 있습니다.{" "}
+              <IconLink to="/contact">
+                <ArrowRight />
+              </IconLink>
+            </SitemapSectionBody>
+          </Section>
+        </Page.Body>
+      </Page>
+    </>
   );
 };
 export const MainPage = styled(_MainPage)``;

--- a/src/app/spc-page/spc-page.tsx
+++ b/src/app/spc-page/spc-page.tsx
@@ -67,7 +67,9 @@ const _SpcPage = ({ className }: { className?: string }) => {
             대회로 2005년부터 개최되었습니다.
           </Section.Body>
         </Section>
-        <HeroImage src={Spc2019Image} alt="SPC 2019" />
+      </Page.Body>
+      <HeroImage src={Spc2019Image} alt="SPC 2019" />
+      <Page.Body>
         <Section>
           <Section.Title>개요</Section.Title>
           <Section.Body>
@@ -224,7 +226,9 @@ const _SpcPage = ({ className }: { className?: string }) => {
             </Table.Wrapper>
           </Section.Body>
         </Section>
-        <HeroImage src={SpcPostersImage} alt="SPC Posters" />
+      </Page.Body>
+      <HeroImage src={SpcPostersImage} alt="SPC Posters" />
+      <Page.Body>
         <SelectedSpcHistoryContextProvider initialValue={{ year: 2023 }}>
           <Section>
             <Section.Title>

--- a/src/common/ui/award/award-table.tsx
+++ b/src/common/ui/award/award-table.tsx
@@ -1,5 +1,16 @@
 import { Table } from "@ui/table/table";
 import { AwardBadge, TAwardBadgeVariant } from "@ui/award-badge/award-badge";
+import { CSSProperties } from "react";
+
+const columnStyle = (headerContent: string): CSSProperties | undefined => {
+  if (headerContent === "#") {
+    return { width: "6em" };
+  }
+  if (headerContent === "=") {
+    return { width: "6em" };
+  }
+  return undefined;
+};
 
 export const AwardTable = ({
   columns,
@@ -16,7 +27,9 @@ export const AwardTable = ({
         <Table.Header>
           <Table.Row>
             {columns.map((h, i) => (
-              <Table.Head key={i}>{h}</Table.Head>
+              <Table.Head key={i} style={columnStyle(h)}>
+                {h}
+              </Table.Head>
             ))}
           </Table.Row>
         </Table.Header>

--- a/src/common/ui/table/table.tsx
+++ b/src/common/ui/table/table.tsx
@@ -52,7 +52,7 @@ const _TableCell = ({
 export const TableCell = styled(_TableCell)`
   padding: 8px;
   text-align: center;
-  vertical-align: top;
+  vertical-align: baseline;
 
   border: 1px solid #ddd;
 `;
@@ -103,6 +103,7 @@ export const Table = styled(_Table)`
   width: 100%;
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: fixed;
 ` as unknown as typeof _Table & {
   Wrapper: typeof TableWrapper;
   Header: typeof TableHeader;


### PR DESCRIPTION
This pull request includes commits that remove padding from hero images and fix the table width.

- The padding was removed from the hero images on the Introduction, History, and Contact pages.
- The table widths in the AwardTable component was fixed to ensure consistent sizing.