### PR TITLE
Update Metropolis font CDN

### DIFF
--- a/src/common/themes/fonts.scss
+++ b/src/common/themes/fonts.scss
@@ -1,4 +1,4 @@
-@import url("https://cdn.jsdelivr.net/npm/@typehaus/metropolis/index.css");
+@import url("https://cdn.jsdelivr.net/npm/@xz/fonts@1/serve/metropolis.min.css");
 @import url("https://webfontworld.github.io/naver/MaruBuri.css");
 @import url("https://cdn.jsdelivr.net/gh/toss/tossface/dist/tossface.css");
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");

--- a/src/common/themes/global.scss
+++ b/src/common/themes/global.scss
@@ -4,14 +4,12 @@
 
 * {
   --black: #212427;
-
   box-sizing: border-box !important;
-  font-family: Metropolis, "Pretendard", "Tossface", "Sans-serif", sans-serif !important;
-
   line-height: 1.4;
 }
 
 body {
+  font-family: "Metropolis", "Pretendard", "Tossface", "Sans-serif", sans-serif;
   max-width: 1600px;
   color: var(--black);
   background: #f1f1f1;


### PR DESCRIPTION
This pull request updates the CDN link for the Metropolis font. The previous link had some errors with kernings, so it has been replaced with a new one.

Resolved #67.